### PR TITLE
The access points get, get_many and page now returns 3 new keys:

### DIFF
--- a/lib/skeletons.rb
+++ b/lib/skeletons.rb
@@ -133,6 +133,9 @@ module BlackStack
                 'create_time' => self.create_time,
                 'update_time' => self.update_time,
                 'delete_time' => self.delete_time,
+                'create_time_ago' => self.create_time.nil? ? nil : htimediff(self.create_time)+' ago',
+                'update_time_ago' => self.update_time.nil? ? nil : htimediff(self.update_time)+' ago',
+                'delete_time_ago' => self.delete_time.nil? ? nil : htimediff(self.delete_time)+' ago',
             }
         end # def to_h
 


### PR DESCRIPTION
create_time_ago
update_time_ago
delete_time_ago

These fields show the creation, updation and deletion time in a friendly way that you can use in the screens.

Example: 26 days ago or 1 year ago